### PR TITLE
Fix run latte-dock command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ See the [installation instruction](./INSTALLATION.md) for others Linux distribut
 ## Run Latte-Dock
 
 Latte is now ready to be used by executing 
-```latte-dock
+```
+latte-dock
 ```
 
 or activating **Latte Dock** from applications menu.


### PR DESCRIPTION
The command wasn't visible before because it was written in the wrong line. Should be working as intended now.