### PR TITLE
Added new dependency not declarated before

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -17,7 +17,7 @@ sudo apt dist-upgrade
 ### Kubuntu and KDE Neon
 
 ```
-sudo apt install cmake extra-cmake-modules qtdeclarative5-dev libqt5x11extras5-dev libkf5iconthemes-dev libkf5plasma-dev libkf5windowsystem-dev libkf5declarative-dev libkf5xmlgui-dev libkf5activities-dev build-essential libxcb-util-dev libkf5wayland-dev git gettext libkf5archive-dev libkf5notifications-dev libxcb-util0-dev libsm-dev libkf5crash-dev libkf5newstuff-dev
+sudo apt install cmake extra-cmake-modules qtdeclarative5-dev libqt5x11extras5-dev libkf5iconthemes-dev libkf5plasma-dev libkf5windowsystem-dev libkf5declarative-dev libkf5xmlgui-dev libkf5activities-dev build-essential libxcb-util-dev libkf5wayland-dev git gettext libkf5archive-dev libkf5notifications-dev libxcb-util0-dev libsm-dev libkf5crash-dev libkf5newstuff-dev libkf5sysguard-dev
 ```
 
 ### Arch Linux


### PR DESCRIPTION
On KDE Neon, using the instalation instructions on INSTALATION.md file and running the install.sh file, the make command failed because of kf5sysguard not installed