### PR TITLE
readme: fix command rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ See the [installation instruction](./INSTALLATION.md) for others Linux distribut
 ## Run Latte-Dock
 
 Latte is now ready to be used by executing 
-```latte-dock
+```
+latte-dock
 ```
 
 or activating **Latte Dock** from applications menu.


### PR DESCRIPTION
Text right after the triple backtick is used to choose syntax highlight. So the `latte-dock` text was never rendered.