### PR TITLE
Increasing the zoom effect and adding "launcherBounceLevel" config option

### DIFF
--- a/containment/package/contents/config/main.xml
+++ b/containment/package/contents/config/main.xml
@@ -21,6 +21,9 @@
     <entry name="zoomLevel" type="Int">
       <default>10</default>
     </entry>
+    <entry name="launcherBounceLevel" type="Int">
+      <default>20</default>
+    </entry>
     <entry name="iconSize" type="Int">
       <default>64</default>
     </entry>

--- a/plasmoid/package/contents/config/main.xml
+++ b/plasmoid/package/contents/config/main.xml
@@ -37,6 +37,9 @@
     <entry name="zoomLevel" type="Int">
       <default>14</default>
     </entry>
+    <entry name="launcherBounceLevel" type="Int">
+      <default>20</default>
+    </entry>
     <entry name="iconSize" type="Int">
       <default>48</default>
     </entry>

--- a/plasmoid/package/contents/ui/task/animations/LauncherAnimation.qml
+++ b/plasmoid/package/contents/ui/task/animations/LauncherAnimation.qml
@@ -51,7 +51,8 @@ SequentialAnimation{
             PropertyAnimation {
                 target: wrapper
                 property: (icList.orientation == Qt.Vertical) ? "tempScaleWidth" : "tempScaleHeight"
-                to: taskItem.containsMouse ? 1+2*(taskItem.parabolic.factor.maxZoom-1) : 1 + (0.65 * (taskItem.parabolic.factor.maxZoom-1))
+                //TODO Add a slider in the AppearanceConfig to adjust the launcherBounceLevel value
+                to: taskItem.containsMouse ? 1+2*(plasmoid.configuration.launcherBounceLevel/10 -1) : 1 + (0.65 * (plasmoid.configuration.launcherBounceLevel /10-1))
                 duration: launcherAnimation.speed
                 easing.type: Easing.OutQuad
             }

--- a/shell/package/contents/configuration/pages/AppearanceConfig.qml
+++ b/shell/package/contents/configuration/pages/AppearanceConfig.qml
@@ -280,7 +280,7 @@ PlasmaComponents.Page {
                         Layout.fillWidth: true
                         value: Number(1 + plasmoid.configuration.zoomLevel / 20).toFixed(2)
                         from: 1
-                        to: 2
+                        to: 5
                         stepSize: 0.05
                         wheelEnabled: false
 


### PR DESCRIPTION
I want to make the parabolic zoom effect more customizable.And in order to achieve that I had to eliminate a flaw in the bounce animation which relied on "taskItem.parabolic.factor.maxZoom" property for the maximum height (or width ) of the animation.In high zoom levels the launcher icons actually went up so high that had created a not-so-appealing effect.