### PR TITLE
Update contextmenu.h

### DIFF
--- a/app/view/contextmenu.h
+++ b/app/view/contextmenu.h
@@ -28,6 +28,7 @@
 #include <QQuickView>
 #include <QMouseEvent>
 #include <QObject>
+#include <QPointer>
 
 namespace Plasma {
 class Applet;


### PR DESCRIPTION
Needed to compile from scratch and saw that QPointer class was not referenced in app/view/contextmenu.h, causing the build to fail.