### PR TITLE
Add the “compact badges” option

### DIFF
--- a/containment/package/contents/config/main.xml
+++ b/containment/package/contents/config/main.xml
@@ -332,6 +332,9 @@
     <entry name="infoBadgeProminentColorEnabled" type="Bool">
       <default>false</default>
     </entry>
+    <entry name="badgesCompactStyle" type="Bool">
+      <default>false</default>
+    </entry>
 
     <entry name="animationLauncherBouncing" type="Bool">
         <default>true</default>

--- a/declarativeimports/components/BadgeText.qml
+++ b/declarativeimports/components/BadgeText.qml
@@ -28,6 +28,7 @@ Rectangle {
     property double previousProportion: 0
 
     property bool style3d: true
+    property bool styleCompact: false
 
     property int numberValue
     property string textValue
@@ -49,13 +50,13 @@ Rectangle {
     property double partSize: height / 2
     property double pi2: Math.PI * 2
 
-    width: Math.max(minimumWidth, valueText.width + 4*units.smallSpacing)
+    width: Math.max(minimumWidth, styleCompact ? 0 : valueText.width + 4*units.smallSpacing)
 
     color: theme.backgroundColor
     radius: (radiusPerCentage / 100) * (height / 2)
     border.width: 0 //Math.max(1,width/64)
 
-    property int borderWidth: 1
+    property int borderWidth: styleCompact ? 0 : 1
     property real borderOpacity: 1
     property color borderColor: theme.textColor
     property color textColor: theme.textColor
@@ -140,6 +141,8 @@ Rectangle {
         elide: Text.ElideRight
 
         text: {
+            if (styleCompact) return "";
+
             if (showNumber) {
                 if (numberValue > 9999) {
                     return i18nc("Over 9999 new messages, overlay, keep short", "9,999+");
@@ -157,7 +160,7 @@ Rectangle {
         font.pixelSize: 0.62 * parent.height
         font.bold: true
         color: textWithBackgroundColor ? parent.color : parent.textColor
-        visible: showNumber || showText
+        visible: (showNumber || showText) && !styleCompact
     }
 
     Rectangle{

--- a/plasmoid/package/contents/config/main.xml
+++ b/plasmoid/package/contents/config/main.xml
@@ -80,10 +80,10 @@
       <label>When "true" Preview window behaves as popup</label>
     </entry>
 
-<!-- MERGED FROM CONTAINMENT -->
-<!-- _______________________ -->
-<!-- BE CAREFUL: Until these values are removed from CONTAINMENT totally and their UPGRADE procedures also, -->
-<!-- their default values should be updated both <here> and at their containment configuration file counterpart -->
+    <!-- MERGED FROM CONTAINMENT -->
+    <!-- _______________________ -->
+    <!-- BE CAREFUL: Until these values are removed from CONTAINMENT totally and their UPGRADE procedures also, -->
+    <!-- their default values should be updated both <here> and at their containment configuration file counterpart -->
 
     <entry name="launchersGroup" type="Enum">
       <choices>
@@ -131,6 +131,9 @@
       <default>true</default>
     </entry>
     <entry name="infoBadgeProminentColorEnabled" type="Bool">
+      <default>false</default>
+    </entry>
+    <entry name="badgesCompactStyle" type="Bool">
       <default>false</default>
     </entry>
 

--- a/plasmoid/package/contents/ui/main.qml
+++ b/plasmoid/package/contents/ui/main.qml
@@ -172,6 +172,7 @@ Item {
     property bool showAudioBadge: plasmoid.configuration.showAudioBadge
     property bool infoBadgeProminentColorEnabled: plasmoid.configuration.infoBadgeProminentColorEnabled
     property bool audioBadgeActionsEnabled: plasmoid.configuration.audioBadgeActionsEnabled
+    property bool badgesCompactStyle: plasmoid.configuration.badgesCompactStyle
     property bool showOnlyCurrentScreen: plasmoid.configuration.showOnlyCurrentScreen
     property bool showOnlyCurrentDesktop: plasmoid.configuration.showOnlyCurrentDesktop
     property bool showOnlyCurrentActivity: plasmoid.configuration.showOnlyCurrentActivity

--- a/plasmoid/package/contents/ui/task/AudioStream.qml
+++ b/plasmoid/package/contents/ui/task/AudioStream.qml
@@ -55,7 +55,8 @@ Item {
 
         LatteComponents.BadgeText {
             anchors.centerIn: parent
-            width: 0.8 * parent.width
+            // To make the icon clearer on the small panel size, we need to enlarge it slightly when the compact badges option enabled.
+            width: 0.8 * parent.width * (root.badgesCompactStyle ? 1.1 : 1)
             height: width
             minimumWidth: width
             maximumWidth: width
@@ -70,11 +71,13 @@ Item {
             radiusPerCentage: 100
 
             style3d: root.badges3DStyle
+            styleCompact: root.badgesCompactStyle
 
             LatteCore.IconItem{
                 id: audioStreamIcon
                 anchors.centerIn: parent
-                width: 0.9*parent.width
+                // To make the icon clearer on the small panel size, we need to enlarge it slightly when the compact badges option enabled.
+                width: 0.9*parent.width * (root.badgesCompactStyle ? 1.05 : 1)
                 height: width
                 colorGroup: PlasmaCore.Theme.ButtonColorGroup
                 usesPlasmaTheme: true

--- a/plasmoid/package/contents/ui/task/ProgressOverlay.qml
+++ b/plasmoid/package/contents/ui/task/ProgressOverlay.qml
@@ -100,6 +100,7 @@ Item {
             }
 
             style3d: root.badges3DStyle
+            styleCompact: root.badgesCompactStyle
             textWithBackgroundColor: false
 
             proportion: {

--- a/shell/package/contents/configuration/pages/TasksConfig.qml
+++ b/shell/package/contents/configuration/pages/TasksConfig.qml
@@ -116,6 +116,17 @@ PlasmaComponents.Page {
                         tasks.configuration.audioBadgeActionsEnabled = checked
                     }
                 }
+
+                LatteComponents.CheckBox {
+                    Layout.maximumWidth: dialog.optionsWidth
+                    text: i18n("Use compact badges")
+                    checked: tasks.configuration.badgesCompactStyle
+                    tooltip: i18n("Hide badge borders, and notifications count from the notification badge")
+
+                    onClicked: {
+                        tasks.configuration.badgesCompactStyle = checked
+                    }
+                }
             }
         }
         //! END: Badges


### PR DESCRIPTION
Allows to make badges cleaner on extremely small panel sizes:

-   removes borders,
-   removes badge text,
-   removes text paddings,
-   slightly increases the size of the audio badge to make it look sharper.

Before:

![Screenshot_20200824_133308](https://user-images.githubusercontent.com/37388187/91034865-5cdadf80-e60e-11ea-99fe-cb6192e77b04.png)

After:

![Screenshot_20200824_133241](https://user-images.githubusercontent.com/37388187/91034905-6bc19200-e60e-11ea-92db-c666a4b59021.png)