### PR TITLE
[Bug] When I press the "Super" key to trigger the app menu, the auto-hide function in maximized windows stops working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,15 @@ include(WriteBasicConfigVersionFile)
 
 include(Definitions.cmake)
 
+#hide warnings
 string(REPLACE "-Wall" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-string(REPLACE "-Wformat-security" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+string(REPLACE "-Wdeprecated-declarations" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+string(REPLACE "-Wreorder" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+string(REPLACE "-Wunused-variable" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+string(REPLACE "-Wunused-parameter" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+
+#add format security check
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat -Werror=format-security")
 
 message(STATUS "COMPILER FLAGS : ${CMAKE_CXX_FLAGS}")
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -382,6 +382,7 @@ inline void configureAboutData()
     about.setHomepage(WEBSITE);
     about.setProgramLogo(QIcon::fromTheme(QStringLiteral("latte-dock")));
     about.setDesktopFileName(QStringLiteral("latte-dock"));
+    about.setProductName(QByteArray("lattedock"));
 
     // Authors
     about.addAuthor(QStringLiteral("Michail Vourlakos"), QString(), QStringLiteral("mvourlakos@gmail.com"));


### PR DESCRIPTION
As the title says, if I click the app menu directly from the dock with the mouse, there are no problems, but if I press the "Super" button on the keyboard, the dock stops to auto-hide on maximized applications and I'm forced to close and reopen Latte dock to make it work again.