### PR TITLE
Add dependency to build instructions for Fedora

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -30,7 +30,7 @@ sudo pacman -S cmake extra-cmake-modules python plasma-framework plasma-desktop 
 
 ### Fedora/RHEL
 ```
-sudo dnf install cmake extra-cmake-modules qt5-qtdeclarative-devel qt5-qtx11extras-devel kf5-kiconthemes-devel kf5-plasma-devel kf5-kwindowsystem-devel kf5-kdeclarative-devel kf5-kxmlgui-devel kf5-kactivities-devel gcc-c++ gcc xcb-util-devel kf5-kwayland-devel git gettext kf5-karchive-devel kf5-knotifications-devel libSM-devel kf5-kcrash-devel kf5-knewstuff-devel kf5-kdbusaddons-devel kf5-kxmlgui-devel kf5-kglobalaccel-devel kf5-kio-devel kf5-kguiaddons-devel kf5-kirigami2-devel kf5-kirigami-devel qt5-qtwayland-devel plasma-wayland-protocols-devel wayland-devel
+sudo dnf install cmake extra-cmake-modules qt5-qtdeclarative-devel qt5-qtx11extras-devel kf5-kiconthemes-devel kf5-plasma-devel kf5-kwindowsystem-devel kf5-kdeclarative-devel kf5-kxmlgui-devel kf5-kactivities-devel gcc-c++ gcc xcb-util-devel kf5-kwayland-devel git gettext kf5-karchive-devel kf5-knotifications-devel libSM-devel kf5-kcrash-devel kf5-knewstuff-devel kf5-kdbusaddons-devel kf5-kxmlgui-devel kf5-kglobalaccel-devel kf5-kio-devel kf5-kguiaddons-devel kf5-kirigami2-devel kf5-kirigami-devel kf5-ki18n-devel qt5-qtwayland-devel plasma-wayland-protocols-devel wayland-devel
 ``` 
 
 ### Building and Installing


### PR DESCRIPTION
<details><summary>Extra Information...</summary>
So, I just installed the Plasma 5.25 update. Broke my Latte Dock. After a bit of web searching, I found out about the current <a href="https://www.reddit.com/r/kde/comments/vfpuox/latte_v010x_has_many_broken_parts_with_plasma_525/?utm_source=share&utm_medium=web2x&context=3">compatibility issues</a> between Plasma 5.25 and Latte Dock 0.10.x. The <a href="https://www.reddit.com/r/kde/comments/vfpuox/comment/icxcafo/?utm_source=share&utm_medium=web2x&context=3">suggestion</a> I found was to use the git version in the meantime.
</details>

When I went to build the git version using the included instructions (on Fedora 36), CMake failed, complaining about a missing `I18n`. So, I just looked for packages with similar names that have fitting descriptions. `kf5-ki18n-devel` was the first one that I tried because the description seemed really promising. CMake immediately was able to continue and Latte Dock finished building and installing successfully. It also functions exactly as expected now.

This small addition to the dependency installation command should reduce the speed bumps for Fedora users.