### PR TITLE
Updated README.md to redirect to aur

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Minimum requirements:
 
 ### Arch Linux
 
-- [Arch Linux](https://www.archlinux.org/packages/?sort=&q=latte-dock)
+- [Arch Linux](https://aur.archlinux.org/packages/latte-dock)
 
 ### Gentoo
 


### PR DESCRIPTION
Changed link of arch linux to redirect to aur. Previously it would redirect to this page:
![image](https://github.com/KDE/latte-dock/assets/109104709/4e9bb7d3-fd1b-4d79-871a-fe0a70bdbc56)
Now it redirects to the aur page where it exists.